### PR TITLE
Fix error on not-found items in fetchone()

### DIFF
--- a/aql/engines/base.py
+++ b/aql/engines/base.py
@@ -299,7 +299,7 @@ class Result(Generic[T]):
     async def row(self) -> Optional[T]:
         cursor = await self.run()
         row = await cursor.fetchone()
-        if self.factory:
+        if row and self.factory:
             return self.factory(*row)
         return None
 
@@ -307,6 +307,6 @@ class Result(Generic[T]):
         cursor = await self.run()
         rows = await cursor.fetchall()
         if self.factory:
-            return [self.factory(*row) for row in rows]
+            return [self.factory(*row) for row in rows if row]
         else:
             return rows


### PR DESCRIPTION
In the case where a row is and factory is set, this will try to tuple-unpack a `None` value into the factory on line 303. This patch adds guard conditions for `.rows` and `.row` so that `None` isn't unpacked


Also, thank you for building this, it's been quite a fun library to work with despite this tiny bug 😄 